### PR TITLE
Cross-portal occurrence tracking development

### DIFF
--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -1328,6 +1328,7 @@ class DwcArchiverCore extends Manager{
 		}
 
 		$symbElem = $newDoc->createElement('symbiota');
+		if(isset($GLOBALS['PORTAL_GUID'])) $symbElem->setAttribute('id',$GLOBALS['PORTAL_GUID']);
 		$dateElem = $newDoc->createElement('dateStamp');
 		$dateElem->appendChild($newDoc->createTextNode(date("c")));
 		$symbElem->appendChild($dateElem);

--- a/classes/SpecUploadBase.php
+++ b/classes/SpecUploadBase.php
@@ -35,6 +35,7 @@ class SpecUploadBase extends SpecUpload{
 	private $targetCharset = 'UTF-8';
 	private $imgFormatDefault = '';
 	private $sourceDatabaseType = '';
+	protected $sourcePortalIndex = 0;
 	private $dbpkCnt = 0;
 
 	function __construct() {
@@ -768,9 +769,8 @@ class SpecUploadBase extends SpecUpload{
 		$this->transferOccurrences();
 		$this->transferIdentificationHistory();
 		$this->transferImages();
-		if($QUICK_HOST_ENTRY_IS_ACTIVE){
-			$this->transferHostAssociations();
-		}
+		if($QUICK_HOST_ENTRY_IS_ACTIVE) $this->transferHostAssociations();
+		$this->crossMapSymbiotaOccurrences();
 		$this->finalCleanup();
 		$this->outputMsg('<li style="">Upload Procedure Complete ('.date('Y-m-d h:i:s A').')!</li>');
 		$this->outputMsg(' ');
@@ -1358,6 +1358,16 @@ class SpecUploadBase extends SpecUpload{
 		$rs->free();
 	}
 
+	private function crossMapSymbiotaOccurrences(){
+		if($this->sourcePortalIndex && $this->collMetadataArr['managementtype'] == 'Snapshot'){
+			$sql = 'INSERT INTO ompublicationoccurlink(occid, targetOccid, portalIndexID, refreshTimestamp)
+				SELECT u.occid, u.dbpk, '.$this->sourcePortalIndex.', NOW() FROM uploadspectemp u LEFT JOIN ompublicationoccurlink l ON u.occid = l.occid
+				WHERE u.occid IS NOT NULL AND u.dbpk IS NOT NULL AND u.collid = '.$this->collId.' AND l.occid IS NULL';
+			if($this->conn->query($sql)) $this->outputMsg('<li style="margin-left:10px;">Occurrences cross-mapped to Symbiota source portal</li> ');
+			else $this->outputMsg('<li style="margin-left:10px;">ERROR linking occurrences to source portal: '.$this->conn->error.'</li> ');
+		}
+	}
+
 	protected function finalCleanup(){
 		$this->outputMsg('<li>Record transfer complete!</li>');
 		$this->outputMsg('<li>Cleaning house...</li>');
@@ -1939,6 +1949,14 @@ class SpecUploadBase extends SpecUpload{
 		}
 		asort($retArr);
 		return $retArr;
+	}
+
+	public function setSourcePortalIndex($index){
+		if($index) $this->sourcePortalIndex = $index;
+	}
+
+	public function getSourcePortalIndex(){
+		return $this->sourcePortalIndex;
 	}
 
 	//Misc functions

--- a/collections/admin/specupload.php
+++ b/collections/admin/specupload.php
@@ -24,6 +24,7 @@ $verifyImages = array_key_exists("verifyimages",$_REQUEST)&&$_REQUEST['verifyima
 $processingStatus = array_key_exists("processingstatus",$_REQUEST)?$_REQUEST['processingstatus']:'';
 $finalTransfer = array_key_exists("finaltransfer",$_REQUEST)?$_REQUEST["finaltransfer"]:0;
 $dbpk = array_key_exists("dbpk",$_REQUEST)?$_REQUEST["dbpk"]:'';
+$sourceIndex = isset($_REQUEST['sourceindex'])?$_REQUEST['sourceindex']:0;
 $recStart = array_key_exists("recstart",$_REQUEST)?$_REQUEST["recstart"]:0;
 $recLimit = array_key_exists("reclimit",$_REQUEST)?$_REQUEST["reclimit"]:1000;
 
@@ -41,6 +42,7 @@ if(!preg_match('/^[a-zA-Z0-9\s_-]+$/',$processingStatus)) $processingStatus = ''
 if($autoMap !== true) $autoMap = false;
 if(!is_numeric($finalTransfer)) $finalTransfer = 0;
 if($dbpk) $dbpk = htmlspecialchars($dbpk);
+if(!is_numeric($sourceIndex)) $sourceIndex = 0;
 if(!is_numeric($recStart)) $recStart = 0;
 if(!is_numeric($recLimit)) $recLimit = 1000;
 
@@ -85,6 +87,7 @@ $duManager->setMatchCatalogNumber($matchCatNum);
 $duManager->setMatchOtherCatalogNumbers($matchOtherCatNum);
 $duManager->setVerifyImageUrls($verifyImages);
 $duManager->setProcessingStatus($processingStatus);
+$duManager->setSourcePortalIndex($sourceIndex);
 
 if($action == 'Automap Fields'){
 	$autoMap = true;
@@ -404,7 +407,8 @@ if($isEditor && $collid){
 			echo "<div style='font-weight:bold;font-size:120%'>".(isset($LANG['UP_STATUS'])?$LANG['UP_STATUS']:'Upload Status').":</div>";
 			echo "<ul style='margin:10px;font-weight:bold;'>";
 			$duManager->uploadData($finalTransfer);
-			echo "</ul>";
+			if($uploadType == $DWCAUPLOAD || $uploadType == $IPTUPLOAD) $sourceIndex = $duManager->getSourcePortalIndex();
+			echo '</ul>';
 			if(!$finalTransfer){
 				?>
 				<fieldset style="margin:15px;">
@@ -511,6 +515,7 @@ if($isEditor && $collid){
 						<input type="hidden" name="verifyimages" value="<?php echo ($verifyImages?'1':'0'); ?>" />
 						<input type="hidden" name="processingstatus" value="<?php echo $processingStatus;?>" />
 						<input type="hidden" name="uspid" value="<?php echo $uspid;?>" />
+						<input type="hidden" name="sourceindex" value="<?php echo $sourceIndex;?>" />
 						<div style="margin:5px;">
 							<button type="submit" name="action" value="activateOccurrences"><?php echo (isset($LANG['TRANS_RECS'])?$LANG['TRANS_RECS']:'Transfer Records to Central Specimen Table'); ?></button>
 						</div>

--- a/config/schema-1.0/dev/db_schema_patch-dev.sql
+++ b/config/schema-1.0/dev/db_schema_patch-dev.sql
@@ -184,6 +184,23 @@ ALTER TABLE `omcollpublications`
 ALTER TABLE `omcollpuboccurlink` 
   RENAME TO  `ompublicationoccurlink` ;
 
+ALTER TABLE `ompublicationoccurlink` 
+  DROP FOREIGN KEY `FK_ompubpubid`;
+
+ALTER TABLE `ompublicationoccurlink` 
+  ADD COLUMN `portalIndexID` INT NOT NULL AFTER `occid`,
+  ADD COLUMN `targetOccid` INT NULL AFTER `pubid`,
+  CHANGE COLUMN `occid` `occid` INT(10) UNSIGNED NOT NULL FIRST,
+  CHANGE COLUMN `pubid` `pubid` INT(10) UNSIGNED NULL DEFAULT NULL ,
+  DROP PRIMARY KEY,
+  ADD PRIMARY KEY (`occid`, `portalIndexID`),
+  ADD INDEX `FK_ompub_portalIndexID_idx` (`portalIndexID` ASC);
+
+ALTER TABLE `ompublicationoccurlink` 
+  ADD CONSTRAINT `FK_ompubpubid`  FOREIGN KEY (`pubid`)  REFERENCES `ompublication` (`pubid`)  ON DELETE CASCADE  ON UPDATE CASCADE,
+  ADD CONSTRAINT `FK_ompub_portalIndexID`  FOREIGN KEY (`portalIndexID`)  REFERENCES `portalindex` (`portalIndexID`)  ON DELETE CASCADE  ON UPDATE CASCADE;
+
+
 CREATE TABLE `omcrowdsourceproject` (
   `csProjID` INT NOT NULL AUTO_INCREMENT,
   `title` VARCHAR(45) NOT NULL,
@@ -242,6 +259,9 @@ CREATE TABLE `portalindex` (
   `notes` VARCHAR(250) NULL,
   `initialTimestamp` TIMESTAMP NULL DEFAULT current_timestamp,
   PRIMARY KEY (`portalIndexID`));
+
+ALTER TABLE `portalindex` 
+  ADD UNIQUE INDEX `UQ_portalIndex_guid` (`guid` ASC);
 
 ALTER TABLE `specprocessorprojects` 
   ADD COLUMN `customStoredProcedure` VARCHAR(45) NULL AFTER `source`,


### PR DESCRIPTION
- Developments required to support filtered-pull data flows
- Add ability for cross portal registration when a DwC-Archive data file from a Symbiota portal is imported into  another Symbiota portal
- Added ability to register external source record for each occurrence record imported into a Symbiota snapshot dataset