### PR TITLE
Occurrence Search bug

### DIFF
--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -161,12 +161,21 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 					$localArr[$k] = 'Locality IS NULL';
 				}
 				else{
-					if(strlen($value) < 4){
-						$tempArr[] = '(o.municipality LIKE "'.$this->cleanInStr($value).'%" OR o.Locality LIKE "%'.$this->cleanInStr($value).'%")';
+					$fullTextSearch = true;
+					if(strlen($value) < 4) $fullTextSearch = false;
+					elseif(strpos($value,' ')){
+						$wordArr = explode(' ',$value);
+						$fullTextSearch = false;
+						foreach($wordArr as $w){
+							if(strlen($w) > 3){
+								$fullTextSearch = true;
+								break;
+							}
+						}
 					}
-					else{
-						$tempArr[] = '(MATCH(f.locality) AGAINST(\'"'.$this->cleanInStr(str_replace('"', '', $value)).'"\' IN BOOLEAN MODE)) ';
-					}
+
+					if($fullTextSearch) $tempArr[] = '(MATCH(f.locality) AGAINST(\'"'.$this->cleanInStr(str_replace('"', '', $value)).'"\' IN BOOLEAN MODE)) ';
+					else $tempArr[] = '(o.municipality LIKE "'.$this->cleanInStr($value).'%" OR o.Locality LIKE "%'.$this->cleanInStr($value).'%")';
 				}
 			}
 			$sqlWhere .= 'AND ('.implode(' OR ',$tempArr).') ';
@@ -450,7 +459,7 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 			//Make the sql valid, but return nothing
 			//$this->sqlWhere = 'WHERE o.occid IS NULL ';
 		}
-		//echo $this->sqlWhere; exit;
+		//echo $this->sqlWhere;
 	}
 
 	private function getAdditionIdentifiers($identFrag){


### PR DESCRIPTION
When all search words are < 3 characters, the fulltext index search fails to return matches. Issue fixed by running a LIKE wildcard match whenever search terms are all < 3 characters. This will return matches, even though it will be slower when database is very large.