### PR TITLE
Occurrence Image adjustments

### DIFF
--- a/classes/OccurrenceEditorImages.php
+++ b/classes/OccurrenceEditorImages.php
@@ -31,6 +31,24 @@ class OccurrenceEditorImages extends OccurrenceEditorManager {
 		return $imageMap;
 	}
 
+	public function getIdentifierArr(){
+		$retArr = array();
+		$sql = 'SELECT o.catalogNumber, o.otherCatalogNumbers, i.identifierValue
+			FROM omoccurrences o LEFT JOIN omoccuridentifiers i ON o.occid = i.occid WHERE (o.occid = '.$this->occid.')';
+		$rs = $this->conn->query($sql);
+		$cnt = 0;
+		while($r = $rs->fetch_object()){
+			if(!$cnt){
+				if($r->catalogNumber) $retArr[] = $r->catalogNumber;
+				if($r->otherCatalogNumbers) $retArr[] = $r->otherCatalogNumbers;
+			}
+			if($r->identifierValue) $retArr[] = $r->identifierValue;
+			$cnt++;
+		}
+		$rs->free();
+		return $retArr;
+	}
+
 	/**
 	 * Takes parameters from a form submission and modifies an existing image record
 	 * in the database.

--- a/collections/editor/imageoccursubmit.php
+++ b/collections/editor/imageoccursubmit.php
@@ -63,7 +63,7 @@ elseif(file_exists('includes/config/occurVarDefault.php')){
     ?>
 	<script src="../../js/jquery.js" type="text/javascript"></script>
 	<script src="../../js/jquery-ui.js" type="text/javascript"></script>
-	<script src="../../js/symb/collections.imageoccursubmit.js?ver=141119" type="text/javascript"></script>
+	<script src="../../js/symb/collections.imageoccursubmit.js?ver=1" type="text/javascript"></script>
 	<script src="../../js/symb/shared.js?ver=141119" type="text/javascript"></script>
 	<script type="text/javascript">
 	function validateImgOccurForm(f){

--- a/collections/editor/includes/config/occurVarColl1_template.php
+++ b/collections/editor/includes/config/occurVarColl1_template.php
@@ -1,15 +1,15 @@
-<?php 
-//Enter one to many custom cascading style sheet files 
+<?php
+//Enter one to many custom cascading style sheet files
 //const $CSSARR = array('example1.css','example2.css');
 
-//Enter one to many custom java script files 
-//const $JSARR = array('example1.js','example2.js'); 
+//Enter one to many custom java script files
+//const $JSARR = array('example1.js','example2.js');
 
-//Enter one to many custom java script files 
+//Enter one to many custom java script files
 //const $PROCESSINGSTATUS = array('unprocessed','Unprocessed/NLP','Stage 1','Stage 2','Stage 3','Pending Duplicate','Pending Review-NfN','Pending Review','Expert Required','Reviewed','Closed');
 
 //Uncomment to turns catalogNumber duplicate search check on/off (on by default)
-//define('CATNUMDUPECHECK',false); 
+//define('CATNUMDUPECHECK',false);
 
 //Uncomment to turns otherCatalogNumbers duplicate search check on/off (off by default)
 //define('OTHERCATNUMDUPECHECK',true);
@@ -19,7 +19,7 @@
 
 //const $ACTIVATEASSOCTAXAAID = false;
 
-//FieldLabel text: uncomment variables and value to modify field labels 
+//FieldLabel text: uncomment variables and value to modify field labels
 //define('CATALOGNUMBERLABEL','');
 //define('OTHERCATALOGNUMBERSLABEL','');
 //define('RECORDEDBYLABEL','');
@@ -29,7 +29,6 @@
 //define('VERBATIMEVENTDATELABEL','');
 //define('YYYYMMDDLABEL','');
 //define('DAYOFYEARLABEL','');
-//define('ENDDATELABEL','');
 //define('SCINAMELABEL','');
 //define('SCIENTIFICNAMEAUTHORSHIPLABEL','');
 //define('FAMILYLABEL','');

--- a/collections/editor/includes/config/occurVarDefault_template.php
+++ b/collections/editor/includes/config/occurVarDefault_template.php
@@ -33,7 +33,6 @@
 //define('VERBATIMEVENTDATELABEL','');
 //define('YYYYMMDDLABEL','');
 //define('DAYOFYEARLABEL','');
-//define('ENDDATELABEL','');
 //define('SCINAMELABEL','');
 //define('SCIENTIFICNAMEAUTHORSHIPLABEL','');
 //define('IDCONFIDENCELABEL','');

--- a/collections/editor/includes/config/occurVarGenObsDefault_template.php
+++ b/collections/editor/includes/config/occurVarGenObsDefault_template.php
@@ -1,15 +1,15 @@
-<?php 
-//Enter one to many custom cascading style sheet files 
+<?php
+//Enter one to many custom cascading style sheet files
 //const $CSSARR = array('example1.css','example2.css');
 
-//Enter one to many custom java script files 
-//const $JSARR = array('example1.js','example2.js'); 
+//Enter one to many custom java script files
+//const $JSARR = array('example1.js','example2.js');
 
-//Enter one to many custom java script files 
+//Enter one to many custom java script files
 //const $PROCESSINGSTATUS = array('unprocessed','Unprocessed/NLP','Stage 1','Stage 2','Stage 3','Pending Duplicate','Pending Review-NfN','Pending Review','Expert Required','Reviewed','Closed');
 
 //Uncomment to turns catalogNumber duplicate search check on/off (on by default)
-//define('CATNUMDUPECHECK',false); 
+//define('CATNUMDUPECHECK',false);
 
 //Uncomment to turns otherCatalogNumbers duplicate search check on/off (off by default)
 //define('OTHERCATNUMDUPECHECK',true);
@@ -19,7 +19,7 @@
 
 //const $ACTIVATEASSOCTAXAAID = false;
 
-//FieldLabel text: uncomment variables and value to modify field labels 
+//FieldLabel text: uncomment variables and value to modify field labels
 //define('CATALOGNUMBERLABEL','');
 //define('OTHERCATALOGNUMBERSLABEL','');
 //define('RECORDEDBYLABEL','');
@@ -29,7 +29,6 @@
 //define('VERBATIMEVENTDATELABEL','');
 //define('YYYYMMDDLABEL','');
 //define('DAYOFYEARLABEL','');
-//define('ENDDATELABEL','');
 //define('SCINAMELABEL','');
 //define('SCIENTIFICNAMEAUTHORSHIPLABEL','');
 //define('FAMILYLABEL','');

--- a/collections/editor/includes/imagetab.php
+++ b/collections/editor/includes/imagetab.php
@@ -17,6 +17,46 @@ $occManager->setOccId($occId);
 $specImgArr = $occManager->getImageMap();
 $photographerArr = $occManager->getPhotographerArr();
 ?>
+<script type="text/javascript">
+	function verifyImgAddForm(f){
+		var filePath = f.elements["imgfile"].value;
+		if(filePath == ""){
+			if(f.elements["imgurl"].value == ""){
+				alert("<?php echo $LANG['SELECT_FILE']; ?>");
+				return false;
+			}
+			else{
+				filePath = f.elements["imgfile"].value
+			}
+		}
+		filePath = filePath.toLowerCase();
+		if((filePath.indexOf(".tif") > -1) || (filePath.indexOf(".png") > -1) && (filePath.indexOf(".dng") > -1)){
+			alert("<?php echo $LANG['NOT_WEB_OPTIMIZED']; ?>");
+			return false;
+		}
+		return true;
+	}
+
+	function verifyImgEditForm(f){
+
+		return true;
+	}
+
+	function verifyImgDelForm(f){
+		if(confirm("<?php echo $LANG['CONFIRM_IMAGE_DELETE']; ?>")){
+			return true;
+		}
+		return false;
+	}
+
+	function verifyImgRemapForm(f){
+		if(f.targetoccid.value == ''){
+			alert("<?php echo $LANG['SELECT_TARGET']; ?>");
+			return false;
+		}
+		return true;
+	}
+</script>
 <div id="imagediv" style="width:795px;">
 	<div style="float:right;cursor:pointer;" onclick="toggle('addimgdiv');" title="<?php echo $LANG['ADD_IMG']; ?>">
 		<img style="border:0px;width:12px;" src="../../images/add.png" />
@@ -371,25 +411,45 @@ $photographerArr = $occManager->getPhotographerArr();
 										</div>
 									</fieldset>
 								</form>
-								<form name="img<?php echo $imgId; ?>remapform" action="occurrenceeditor.php" method="post" onsubmit="return verifyImgRemapForm(this);">
-									<fieldset style="padding:15px">
-										<legend><b><?php echo $LANG['REMAP_TO_ANOTHER']; ?></b></legend>
-										<div>
-											<b><?php echo $LANG['OCC_REC_NUM']; ?>:</b>
-											<input id="imgoccid-<?php echo $imgId; ?>" name="targetoccid" type="text" value="" />
-											<span style="cursor:pointer;color:blue;"  onclick="openOccurrenceSearch('imgoccid-<?php echo $imgId; ?>')">
-												<?php echo $LANG['OPEN_LINK_AID']; ?>
-											</span>
-										</div>
-										<div style="margin:10px 20px;">
-											<input name="occid" type="hidden" value="<?php echo $occId; ?>" />
-											<input type="hidden" name="imgid" value="<?php echo $imgId; ?>" />
-											<input type="hidden" name="occindex" value="<?php echo $occIndex; ?>" />
-											<input type="hidden" name="csmode" value="<?php echo $crowdSourceMode; ?>" />
-											<button type="submit" name="submitaction" value="Remap Image"><?php echo $LANG['REMAP_IMG']; ?></button>
-										</div>
-									</fieldset>
-								</form>
+								<?php
+								$displayRemapForm = true;
+								$idArr = $occManager->getIdentifierArr();
+								$testArr = array();
+								if($imgArr['origurl']) $testArr[] = $imgArr['origurl'];
+								if($imgArr['url']) $testArr[] = $imgArr['url'];
+								foreach($idArr as $idStr){
+									foreach($testArr as $url){
+										if($testStr = substr($url, strrpos($url, '/'))){
+											if(strpos($testStr,$idStr) !== false && !preg_match('/_\d{10}[_\.]{1}/', $testStr)){
+												$displayRemapForm = false;
+												break 2;
+											}
+										}
+									}
+								}
+								if($displayRemapForm){
+									?>
+									<form name="img<?php echo $imgId; ?>remapform" action="occurrenceeditor.php" method="post" onsubmit="return verifyImgRemapForm(this);">
+										<fieldset style="padding:15px">
+											<legend><b><?php echo $LANG['REMAP_TO_ANOTHER']; ?></b></legend>
+											<div>
+												<b><?php echo $LANG['TARGET_OCCID']; ?>:</b>
+												<input id="imgdisplay-<?php echo $imgId; ?>" name="displayoccid" type="text" value="" disabled style="width:70px" />
+												<span onclick="openOccurrenceSearch('<?php echo $imgId; ?>');return false"><a href="#"><?php echo $LANG['OPEN_LINK_AID']; ?></a></span>
+											</div>
+											<div style="margin:10px 20px;">
+												<input id="imgoccid-<?php echo $imgId; ?>" name="targetoccid" type="hidden" value="" />
+												<input name="occid" type="hidden" value="<?php echo $occId; ?>" />
+												<input type="hidden" name="imgid" value="<?php echo $imgId; ?>" />
+												<input type="hidden" name="occindex" value="<?php echo $occIndex; ?>" />
+												<input type="hidden" name="csmode" value="<?php echo $crowdSourceMode; ?>" />
+												<button type="submit" name="submitaction" value="Remap Image"><?php echo $LANG['REMAP_IMG']; ?></button>
+											</div>
+										</fieldset>
+									</form>
+									<?php
+								}
+								?>
 								<form action="occurrenceeditor.php" method="post">
 									<fieldset style="padding:15px">
 										<legend><b><?php echo $LANG['LINK_TO_BLANK']; ?></b></legend>

--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -447,7 +447,7 @@ else{
     }
     else{
 		?>
-		<link href="../../css/symb/occurrenceeditor.css?ver=5" type="text/css" rel="stylesheet" id="editorCssLink" />
+		<link href="../../css/symb/occurrenceeditor.css?ver=6" type="text/css" rel="stylesheet" id="editorCssLink" />
 		<?php
 		if(isset($CSSARR)){
 			foreach($CSSARR as $cssVal){
@@ -503,7 +503,7 @@ else{
 	<script src="../../js/symb/collections.coordinateValidation.js?ver=2" type="text/javascript"></script>
 	<script src="../../js/symb/wktpolygontools.js?ver=2" type="text/javascript"></script>
 	<script src="../../js/symb/collections.georef.js?ver=1" type="text/javascript"></script>
-	<script src="../../js/symb/collections.editor.main.js?ver=12" type="text/javascript"></script>
+	<script src="../../js/symb/collections.editor.main.js?ver=13b" type="text/javascript"></script>
 	<script src="../../js/symb/collections.editor.tools.js?ver=4" type="text/javascript"></script>
 	<script src="../../js/symb/collections.editor.imgtools.js?ver=1" type="text/javascript"></script>
 	<script src="../../js/jquery.imagetool-1.7.js?ver=140310" type="text/javascript"></script>
@@ -731,7 +731,6 @@ else{
 													<?php
 												}
 											}
-
 											?>
 											<div style="clear:both;">
 												<div id="catalogNumberDiv">
@@ -859,10 +858,6 @@ else{
 													<input type="text" name="startdayofyear" value="<?php echo array_key_exists('startdayofyear',$occArr)?$occArr['startdayofyear']:''; ?>" onchange="inputIsNumeric(this, 'Start Day of Year');fieldChanged('startdayofyear');" title="<?php echo (isset($LANG['START_DOY'])?$LANG['START_DOY']:'Start Day of Year'); ?>" /> -
 													<input type="text" name="enddayofyear" value="<?php echo array_key_exists('enddayofyear',$occArr)?$occArr['enddayofyear']:''; ?>" onchange="inputIsNumeric(this, 'End Day of Year');fieldChanged('enddayofyear');" title="<?php echo $LANG['END_DOY']; ?>" />
 												</div>
-                                                <div id="endDateDiv">
-                                                    <?php echo (defined('ENDDATELABEL')?ENDDATELABEL:'Calculate End Day of Year'); ?>:
-                                                    <input type="text" id="endDate" value="" onchange="endDateChanged();" />
-                                                </div>
 											</div>
 											<?php
 											if(isset($ACTIVATE_EXSICCATI) && $ACTIVATE_EXSICCATI){

--- a/collections/misc/occurrencesearch.php
+++ b/collections/misc/occurrencesearch.php
@@ -1,23 +1,26 @@
 <?php
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT.'/classes/OccurrenceSupport.php');
-header("Content-Type: text/html; charset=".$CHARSET);
+header('Content-Type: text/html; charset='.$CHARSET);
 
-$targetId = $_REQUEST["targetid"];
-$collid = array_key_exists("collid",$_REQUEST)?$_REQUEST["collid"]:0;
-$action = array_key_exists("action",$_POST)?$_POST["action"]:'';
-$catalogNumber = array_key_exists("catalognumber",$_POST)?$_POST['catalognumber']:'';
-$otherCatalogNumbers = array_key_exists("othercatalognumbers",$_POST)?$_POST['othercatalognumbers']:'';
-$recordedBy = array_key_exists("recordedby",$_POST)?$_POST['recordedby']:'';
-$recordNumber = array_key_exists("recordnumber",$_POST)?$_POST['recordnumber']:'';
+$targetId = $_REQUEST['targetid'];
+$collid = array_key_exists('collid',$_REQUEST)?$_REQUEST['collid']:0;
+$action = array_key_exists('action',$_POST)?$_POST['action']:'';
+$catalogNumber = array_key_exists('catalognumber',$_POST)?$_POST['catalognumber']:'';
+$otherCatalogNumbers = array_key_exists('othercatalognumbers',$_POST)?$_POST['othercatalognumbers']:'';
+$recordedBy = array_key_exists('recordedby',$_POST)?$_POST['recordedby']:'';
+$recordNumber = array_key_exists('recordnumber',$_POST)?$_POST['recordnumber']:'';
+
+//Sanitation
+if(!is_numeric($collid)) $collid = 0;
+$catalogNumber = filter_var($catalogNumber,FILTER_SANITIZE_STRING);
+$otherCatalogNumbers = filter_var($otherCatalogNumbers,FILTER_SANITIZE_STRING);
+$recordedBy = filter_var($recordedBy,FILTER_SANITIZE_STRING);
+$recordNumber = filter_var($recordNumber,FILTER_SANITIZE_STRING);
 
 $collEditorArr = array();
-if(array_key_exists("CollAdmin",$USER_RIGHTS)){
-	$collEditorArr = $USER_RIGHTS['CollAdmin'];
-}
-if(array_key_exists("CollEditor",$USER_RIGHTS)){
-	$collEditorArr = array_unique(array_merge($collEditorArr,$USER_RIGHTS['CollEditor']));
-}
+if(array_key_exists('CollAdmin',$USER_RIGHTS)) $collEditorArr = $USER_RIGHTS['CollAdmin'];
+if(array_key_exists('CollEditor',$USER_RIGHTS)) $collEditorArr = array_unique(array_merge($collEditorArr,$USER_RIGHTS['CollEditor']));
 
 $occManager = new OccurrenceSupport();
 $collArr = $occManager->getCollectionArr($IS_ADMIN?'all':$collEditorArr);
@@ -28,20 +31,14 @@ $collArr = $occManager->getCollectionArr($IS_ADMIN?'all':$collEditorArr);
 	<title><?php echo $DEFAULT_TITLE; ?> Occurrence Search Page</title>
 	<?php
 	$activateJQuery = true;
-	if(file_exists($SERVER_ROOT.'/includes/head.php')){
-		include_once($SERVER_ROOT.'/includes/head.php');
-    }
-	else{
-		echo '<link href="'.$CLIENT_ROOT.'/css/jquery-ui.css" type="text/css" rel="stylesheet" />';
-		echo '<link href="'.$CLIENT_ROOT.'/css/base.css?ver=1" type="text/css" rel="stylesheet" />';
-		echo '<link href="'.$CLIENT_ROOT.'/css/main.css?ver=1" type="text/css" rel="stylesheet" />';
-	}
+	include_once($SERVER_ROOT.'/includes/head.php');
 	?>
 	<script src="../../js/jquery.js" type="text/javascript"></script>
 	<script src="../../js/jquery-ui.js" type="text/javascript"></script>
 	<script type="text/javascript">
 	    function updateParentForm(occId) {
-	        opener.document.getElementById("<?php echo $targetId;?>").value = occId;
+	        opener.document.getElementById("imgdisplay-<?php echo $targetId;?>").value = occId;
+	        opener.document.getElementById("imgoccid-<?php echo $targetId;?>").value = occId;
 	        self.close();
 	        return false;
 	    }
@@ -97,7 +94,6 @@ $collArr = $occManager->getCollectionArr($IS_ADMIN?'all':$collEditorArr);
 	</script>
 </head>
 <body>
-	<!-- This is inner text! -->
 	<div id="innertext">
 		<?php
 		if($collEditorArr){
@@ -121,19 +117,19 @@ $collArr = $occManager->getCollectionArr($IS_ADMIN?'all':$collEditorArr);
 					</div>
 					<div style="clear:both;padding:2px;">
 						<div style="float:left;width:130px;">Catalog #:</div>
-						<div style="float:left;"><input name="catalognumber" type="text" /></div>
+						<div style="float:left;"><input name="catalognumber" type="text" value="<?php echo $catalogNumber; ?>" /></div>
 					</div>
 					<div style="clear:both;padding:2px;">
 						<div style="float:left;width:130px;">Other Catalog #:</div>
-						<div style="float:left;"><input name="othercatalognumbers" type="text" /></div>
+						<div style="float:left;"><input name="othercatalognumbers" type="text" value="<?php echo $otherCatalogNumbers; ?>" /></div>
 					</div>
 					<div style="clear:both;padding:2px;">
 						<div style="float:left;width:130px;">Collector Last Name:</div>
-						<div style="float:left;"><input name="recordedby" type="text" /></div>
+						<div style="float:left;"><input name="recordedby" type="text"  value="<?php echo $recordedBy; ?>" /></div>
 					</div>
 					<div style="clear:both;padding:2px;">
 						<div style="float:left;width:130px;">Collector Number:</div>
-						<div style="float:left;"><input name="recordnumber" type="text" /></div>
+						<div style="float:left;"><input name="recordnumber" type="text" value="<?php echo $recordNumber; ?>" /></div>
 					</div>
 					<div style="clear:both;padding:2px;">
 						<input name="action" type="submit" value="Search Occurrences" />

--- a/content/lang/collections/editor/includes/imagetab.en.php
+++ b/content/lang/collections/editor/includes/imagetab.en.php
@@ -5,6 +5,10 @@ Language: English
 ------------------
 */
 
+$LANG['SELECT_FILE'] = 'Select an image file or enter a URL to an existing image';
+$LANG['NOT_WEB_OPTIMIZED'] = 'Input file must be a web-optimized image (e.g. jpg). File appears to be an archival image (e.g. tif, png, dng, etc)';
+$LANG['CONFIRM_IMAGE_DELETE'] = 'Are you sure you want to delete this image? Note that the physical image will be deleted from the server if checkbox is selected';
+$LANG['SELECT_TARGET'] = 'Select target record';
 $LANG['ADD_IMG'] = 'Add a New Image';
 $LANG['SELECT_IMG'] = 'Select an image file located on your computer that you want to upload';
 $LANG['ENTER_URL'] = 'Enter URL';
@@ -45,8 +49,8 @@ $LANG['DEL_IMG'] = 'Delete Image';
 $LANG['REM_FROM_SERVER'] = 'Remove image from server';
 $LANG['RM_DB_NOT_SERVER'] = 'Note: leaving unchecked removes image from database without removing from server)';
 $LANG['REMAP_TO_ANOTHER'] = 'Remap to Another Specimen';
-$LANG['OCC_REC_NUM'] = 'Occurrence Record #';
-$LANG['OPEN_LINK_AID'] = 'Open Occurrence Linking Aid';
+$LANG['TARGET_OCCID'] = 'Target record ID';
+$LANG['OPEN_LINK_AID'] = 'Occurrence Linking Tool';
 $LANG['REMAP_IMG'] = 'Remap Image';
 $LANG['LINK_TO_BLANK'] = 'Link to a New Blank Occurrence Record within Collection';
 $LANG['LINK_TO_NEW'] = 'Link to New Occurrence';

--- a/content/lang/collections/editor/includes/imagetab.es.php
+++ b/content/lang/collections/editor/includes/imagetab.es.php
@@ -5,6 +5,10 @@ Language: Español
 ------------------
 */
 
+$LANG['SELECT_FILE'] = 'Seleccione un archivo de imagen o ingrese una URL a una imagen existente';
+$LANG['NOT_WEB_OPTIMIZED'] = 'El archivo de entrada debe ser una imagen optimizada para la web (por ejemplo, jpg). El archivo parece ser una imagen de archivo (por ejemplo, tif, png, dng, etc.)';
+$LANG['CONFIRM_IMAGE_DELETE'] = '¿Está seguro de que desea eliminar esta imagen? Tenga en cuenta que la imagen física se eliminará del servidor si se selecciona la casilla de verificación';
+$LANG['SELECT_TARGET'] = 'Seleccionar registro de destino';
 $LANG['ADD_IMG'] = 'Añadir una Nueva Imagen';
 $LANG['SELECT_IMG'] = 'Seleccionar un archivo de imagen localizado en su computadora que desee subir';
 $LANG['ENTER_URL'] = 'Introducir URL';
@@ -45,7 +49,7 @@ $LANG['DEL_IMG'] = 'Eliminar Imagen';
 $LANG['REM_FROM_SERVER'] = 'Remover imagen del servidor';
 $LANG['RM_DB_NOT_SERVER'] = 'Nota: al no seleccionar se remueve la imagen de la base de datos sin removerla del servidor)';
 $LANG['REMAP_TO_ANOTHER'] = 'Remapear a Otro Espécimen';
-$LANG['OCC_REC_NUM'] = 'Registro de Occurrencia #';
+$LANG['TARGET_OCCID'] = 'Registro objetivo';
 $LANG['OPEN_LINK_AID'] = 'Abrir Ayuda para Enlace de Ocurrencias';
 $LANG['REMAP_IMG'] = 'Remapear Imagen';
 $LANG['LINK_TO_BLANK'] = 'Enlazar a Nuevo Registro de Ocurrencia en Blanco entre la Colección';

--- a/content/lang/collections/editor/includes/imagetab.fr.php
+++ b/content/lang/collections/editor/includes/imagetab.fr.php
@@ -5,6 +5,10 @@ Language: Français (French)
 ------------------
 */
 
+$LANG['SELECT_FILE'] = 'Sélectionnez un fichier image ou entrez une URL vers une image existante';
+$LANG['NOT_WEB_OPTIMIZED'] = "Le fichier d'entrée doit être une image optimisée pour le Web (par exemple, jpg). Le fichier semble être une image d'archive (par exemple, tif, png, dng, etc.)";
+$LANG['CONFIRM_IMAGE_DELETE'] = "Êtes-vous sûr de vouloir supprimer cette image? Notez que l'image physique sera supprimée du serveur si la case est cochée";
+$LANG['SELECT_TARGET'] = "Sélectionnez l'enregistrement cible";
 $LANG['ADD_IMG'] = 'Ajouter une Nouvelle Image';
 $LANG['SELECT_IMG'] = 'Sélectionnez un fichier image situé sur votre ordinateur que vous souhaitez télécharger';
 $LANG['ENTER_URL'] = 'Entrer URL';
@@ -45,7 +49,7 @@ $LANG['DEL_IMG'] = 'Supprimer Image';
 $LANG['REM_FROM_SERVER'] = 'Supprimer image du serveur';
 $LANG['RM_DB_NOT_SERVER'] = "Remarque: ne pas cocher la case supprime l'image de la base de données sans la supprimer du serveur)";
 $LANG['REMAP_TO_ANOTHER'] = 'Remapper à Autre Spécimen';
-$LANG['OCC_REC_NUM'] = 'Enregistrement Occurrence #';
+$LANG['TARGET_OCCID'] = 'Enregistrement Occurrence #';
 $LANG['OPEN_LINK_AID'] = "Ouvrir Aide de Liaison d'Occurrence";
 $LANG['REMAP_IMG'] = 'Remapper Image';
 $LANG['LINK_TO_BLANK'] = "Lier à Nouvel Enregistrement d'Occurrence Vierge dans Collection";

--- a/js/symb/collections.editor.main.js
+++ b/js/symb/collections.editor.main.js
@@ -1238,46 +1238,6 @@ function verifyDetForm(f){
 	return true;
 }
 
-//Image tab form methods 
-function verifyImgAddForm(f){
-	var filePath = f.elements["imgfile"].value;
-	if(filePath == ""){
-		if(f.elements["imgurl"].value == ""){
-			alert("Select an image file or enter a URL to an existing image");
-			return false;
-		}
-		else{
-			filePath = f.elements["imgfile"].value
-		}
-	}
-	filePath = filePath.toLowerCase();
-	if((filePath.indexOf(".tif") > -1) || (filePath.indexOf(".png") > -1) && (filePath.indexOf(".dng") > -1)){
-		alert("Input file must be a web-optimized image (e.g. jpg). File appears to be an archival image (e.g. tif, png, dng, etc).");
-		return false;
-	}
-	return true;
-}
-
-function verifyImgEditForm(f){
-
-	return true;
-}
-
-function verifyImgDelForm(f){
-	if(confirm('Are you sure you want to delete this image? Note that the physical image will be deleted from the server if checkbox is selected.')){
-		return true;
-	}
-	return false;
-}
-
-function verifyImgRemapForm(f){
-	if(f.targetoccid.value == ''){
-		alert("Enter the occurrence record identifier (occid) of the occurrence record you want to transfer to");
-		return false;
-	}
-	return true;
-}
-
 //Misc
 function dwcDoc(dcTag){
 	dwcWindow=open("https://biokic.github.io/symbiota-docs/editor/edit/fields/#"+dcTag,"dwcaid","width=1250,height=300,left=20,top=20,scrollbars=1");


### PR DESCRIPTION
- Image transfer improvement: selection of target occurrence can only be done through the linking tool. Previously, users could manually enter target occid, but folks were often adding catalog numbers or other identifiers, which would fail and disassociate image from all occurrences
- Only allow images to be transferred to another occurrence if they haven't been batch loaded on an institutional server (CyVerse excluded)
- Include error and form validation message within language files
- Various improvements