### PR TITLE
Remove auto-hiding of countries loan management

### DIFF
--- a/collections/loans/reports/defaultenvelope.php
+++ b/collections/loans/reports/defaultenvelope.php
@@ -50,7 +50,7 @@ if($outputMode == 'doc'){
 		$textrun->addText(htmlspecialchars($invoiceArr['address2']),'toAddressFont');
 		$textrun->addTextBreak(1);
 	}
-	$textrun->addText(htmlspecialchars($invoiceArr['city'].', '.$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode']),'toAddressFont');
+	$textrun->addText(htmlspecialchars($invoiceArr['city'].($invoiceArr['stateprovince']?', ':'').$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode']),'toAddressFont');
 	$textrun->addTextBreak(1);
 	$textrun->addText(htmlspecialchars($invoiceArr['country']),'toAddressFont');
 
@@ -113,7 +113,7 @@ else{
 								if($invoiceArr['institutionname2']) echo $invoiceArr['institutionname2'].'<br />';
 								if($invoiceArr['address1']) echo $invoiceArr['address1'].'<br />';
 								if($invoiceArr['address2']) echo $invoiceArr['address2'].'<br />';
-								echo $invoiceArr['city'].', '.$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode'].'<br/>';
+								echo $invoiceArr['city'].($invoiceArr['stateprovince']?', ':'').$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode'].'<br/>';
 								echo $invoiceArr['country'];
 								?>
 							</div>

--- a/collections/loans/reports/defaultinvoice.php
+++ b/collections/loans/reports/defaultinvoice.php
@@ -18,8 +18,6 @@ $spanish = ($languageDef == 1 || $languageDef == 2);
 
 $invoiceArr = $loanManager->getInvoiceInfo($identifier,$loanType);
 $addressArr = $loanManager->getFromAddress($collId);
-$isInternational = true;
-if($invoiceArr['country'] == $addressArr['country']) $isInternational = false;
 
 if($loanType == 'exchange'){
 	$transType = 0;
@@ -97,7 +95,7 @@ if($outputMode == 'doc'){
 		$textrun->addText(htmlspecialchars($addressArr['address2']),'headerFont');
 		$textrun->addTextBreak(1);
 	}
-	$textrun->addText(htmlspecialchars($addressArr['city'].', '.$addressArr['stateprovince'].' '.$addressArr['postalcode'].($isInternational?' '.$addressArr['country']:'')),'headerFont');
+	$textrun->addText(htmlspecialchars($addressArr['city'].($addressArr['stateprovince']?', ':'').$addressArr['stateprovince'].' '.$addressArr['postalcode'].' '.$addressArr['country']),'headerFont');
 	$textrun->addTextBreak(1);
 	$textrun->addText(htmlspecialchars($addressArr['phone']),'headerFont');
 	$textrun->addTextBreak(2);
@@ -123,11 +121,9 @@ if($outputMode == 'doc'){
 		$textrun->addText(htmlspecialchars($invoiceArr['address2']),'toAddressFont');
 		$textrun->addTextBreak(1);
 	}
-	$textrun->addText(htmlspecialchars($invoiceArr['city'].', '.$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode']),'toAddressFont');
-	if($isInternational){
-		$textrun->addTextBreak(1);
-		$textrun->addText(htmlspecialchars($invoiceArr['country']),'toAddressFont');
-	}
+	$textrun->addText(htmlspecialchars($invoiceArr['city'].($invoiceArr['stateprovince']?', ':'').$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode']),'toAddressFont');
+	$textrun->addTextBreak(1);
+	$textrun->addText(htmlspecialchars($invoiceArr['country']),'toAddressFont');
 	$cell = $table->addCell(5000,$cellStyle);
 	$textrun = $cell->addTextRun('identifier');
 	$textrun->addText(htmlspecialchars(date('l').', '.date('F').' '.date('j').', '.date('Y')),'identifierFont');
@@ -426,7 +422,7 @@ else{
 									</tr>
 								<?php } ?>
 								<tr>
-									<td><?php echo $addressArr['city'].', '.$addressArr['stateprovince'].' '.$addressArr['postalcode']; ?> <?php if($isInternational){echo $addressArr['country'];} ?></td>
+									<td><?php echo $addressArr['city'].($addressArr['stateprovince']?', ':'').$addressArr['stateprovince'].' '.$addressArr['postalcode'].' '.$addressArr['country']; ?></td>
 								</tr>
 								<tr>
 									<td><?php echo $addressArr['phone']; ?></td>
@@ -452,8 +448,8 @@ else{
 											if($invoiceArr['institutionname2']) echo $invoiceArr['institutionname2'].'<br />';
 											if($invoiceArr['address1']) echo $invoiceArr['address1'].'<br />';
 											if($invoiceArr['address2']) echo $invoiceArr['address2'].'<br />';
-											echo $invoiceArr['city'].', '.$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode'];
-											if($isInternational) echo '<br />'.$invoiceArr['country'];
+											echo $invoiceArr['city'].($invoiceArr['stateprovince']?', ':'').$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode'];
+											echo '<br />'.$invoiceArr['country'];
 											?>
 										</div>
 									</td>

--- a/collections/loans/reports/defaultmailinglabel.php
+++ b/collections/loans/reports/defaultmailinglabel.php
@@ -20,8 +20,6 @@ else{
 	$invoiceArr = $loanManager->getInvoiceInfo($identifier,$loanType);
 }
 $addressArr = $loanManager->getFromAddress($collId);
-$isInternational = true;
-if($invoiceArr['country'] == $addressArr['country']) $isInternational = false;
 
 if($outputMode == 'doc'){
 	$phpWord = new \PhpOffice\PhpWord\PhpWord();
@@ -47,11 +45,9 @@ if($outputMode == 'doc'){
 		$textrun->addText(htmlspecialchars($addressArr['address2']),'fromAddressFont');
 		$textrun->addTextBreak(1);
 	}
-	$textrun->addText(htmlspecialchars($addressArr['city'].', '.$addressArr['stateprovince'].' '.$addressArr['postalcode']),'fromAddressFont');
-	if($isInternational){
-		$textrun->addTextBreak(1);
-		$textrun->addText(htmlspecialchars($addressArr['country']),'fromAddressFont');
-	}
+	$textrun->addText(htmlspecialchars($addressArr['city'].($addressArr['stateprovince']?', ':'').$addressArr['stateprovince'].' '.$addressArr['postalcode']),'fromAddressFont');
+	$textrun->addTextBreak(1);
+	$textrun->addText(htmlspecialchars($addressArr['country']),'fromAddressFont');
 	if($accountNum){
 		$textrun->addTextBreak(1);
 		$textrun->addText(htmlspecialchars('(Acct. #'.$accountNum.')'),'fromAddressFont');
@@ -74,12 +70,9 @@ if($outputMode == 'doc'){
 		$textrun->addText(htmlspecialchars($invoiceArr['address2']),'toAddressFont');
 		$textrun->addTextBreak(1);
 	}
-	$textrun->addText(htmlspecialchars($invoiceArr['city'].', '.$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode']),'toAddressFont');
-	if($isInternational){
-		$textrun->addTextBreak(1);
-		$textrun->addText(htmlspecialchars($invoiceArr['country']),'toAddressFont');
-	}
-
+	$textrun->addText(htmlspecialchars($invoiceArr['city'].($invoiceArr['stateprovince']?', ':'').$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode']),'toAddressFont');
+	$textrun->addTextBreak(1);
+	$textrun->addText(htmlspecialchars($invoiceArr['country']),'toAddressFont');
 	$targetFile = $SERVER_ROOT.'/temp/report/'.$PARAMS_ARR['un'].'_mailing_label.docx';
 	$phpWord->save($targetFile, 'Word2007');
 
@@ -132,10 +125,7 @@ else{
 								if($addressArr['address2']){
 									echo $addressArr['address2'].'<br />';
 								}
-								echo $addressArr['city'].', '.$addressArr['stateprovince'].' '.$addressArr['postalcode'].'<br />';
-								if($isInternational){
-									echo $addressArr['country'].'<br />';
-								}
+								echo $addressArr['city'].($addressArr['stateprovince']?', ':'').$addressArr['stateprovince'].' '.$addressArr['postalcode'].'<br />'.$addressArr['country'].'<br />';
 								if($accountNum){
 									echo '(Acct. #'.$accountNum.')<br />';
 								}
@@ -157,10 +147,7 @@ else{
 								if($invoiceArr['address2']){
 									echo $invoiceArr['address2'].'<br />';
 								}
-								echo $invoiceArr['city'].', '.$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode'];
-								if($isInternational){
-									echo '<br />'.$invoiceArr['country'];
-								}
+								echo $invoiceArr['city'].($invoiceArr['stateprovince']?', ':'').$invoiceArr['stateprovince'].' '.$invoiceArr['postalcode'].'<br />'.$invoiceArr['country'];
 								?>
 							</div>
 						</td>


### PR DESCRIPTION
Invoices, envelopes, and mailing labels used to hide the country from the address if sending and receiving countries were the same. I removed this. I also added an if-then statement to only include a comma if a state/province is provided.