### PR TITLE
Fix appearance of secondary cat #

### DIFF
--- a/collections/individual/index.php
+++ b/collections/individual/index.php
@@ -411,6 +411,12 @@ $traitArr = $indManager->getTraitArr();
 									if(!$catTag) $catTag = $LANG['OTHER_CATALOG_NUMBERS'];
 									echo '<div class="assoccatnum-div"><label>'.$catTag.':</label> '.implode('; ', $catValueArr).'</div>';
 								}
+							} elseif(substr($occArr['othercatalognumbers'],0,1)=='['){
+									$otherCatArr = json_decode($occArr['othercatalognumbers'],true);
+									foreach($otherCatArr as $catTag => $catValueArr){
+										if(!$catTag) $catTag = $LANG['OTHER_CATALOG_NUMBERS'];
+										echo '<div class="assoccatnum-div"><label>'.$catTag.':</label> '.implode('; ', $catValueArr).'</div>';
+									}
 							}
 							else{
 								?>


### PR DESCRIPTION
When no tag name was specified, the secondary catalog numbers would show up in brackets. See https://github.com/BioKIC/symbiota-docs/issues/310