### PR TITLE
Hotfix 2023 06 19 (#518)

### DIFF
--- a/classes/OccurrenceCollectionProfile.php
+++ b/classes/OccurrenceCollectionProfile.php
@@ -516,7 +516,7 @@ class OccurrenceCollectionProfile extends OmCollections{
 			ob_flush();
 		}
 		$occurMaintenance->generalOccurrenceCleaning();
-		$occurMaintenance->batchUpdateGeoreferenceIndex();
+		//$occurMaintenance->batchUpdateGeoreferenceIndex();
 		if($verbose){
 			echo '<li>Updating statistics...</li>';
 			flush();

--- a/classes/OccurrenceIndividual.php
+++ b/classes/OccurrenceIndividual.php
@@ -968,20 +968,34 @@ class OccurrenceIndividual extends Manager{
 		return $returnArr;
 	}
 
-	public function checkArchive(){
+	public function checkArchive($guid){
 		$retArr = array();
+		$archiveObject = '';
+		$notes = '';
+		$sql = 'SELECT archiveobj, remarks FROM omoccurarchive ';
 		if($this->occid){
-			$sql = 'SELECT archiveobj, remarks FROM omoccurarchive WHERE occid = '.$this->occid;
-			if($rs = $this->conn->query($sql)){
-				if($r = $rs->fetch_object()){
-					$retArr['obj'] = json_decode($r->archiveobj, true);
-					$retArr['notes'] = $r->remarks;
-				}
-				$rs->free();
+			$sql .= 'WHERE occid = ?';
+			if($stmt = $this->conn->prepare($sql)){
+				$stmt->bind_param('i', $this->occid);
+				$stmt->execute();
+				$stmt->bind_result($archiveObject, $notes);
+				$stmt->fetch();
+				$stmt->close();
 			}
-			else{
-				trigger_error('ERROR checking archive: '.$this->conn->error,E_USER_WARNING);
+		}
+		if(!$retArr && $guid){
+			$sql .= 'WHERE (occurrenceid = ?) OR (recordID = ?) ';
+			if($stmt = $this->conn->prepare($sql)){
+				$stmt->bind_param('ss', $guid, $guid);
+				$stmt->execute();
+				$stmt->bind_result($archiveObject, $notes);
+				$stmt->fetch();
+				$stmt->close();
 			}
+		}
+		if($archiveObject){
+			$retArr['obj'] = json_decode($archiveObject, true);
+			$retArr['notes'] = $notes;
 		}
 		return $retArr;
 	}

--- a/classes/TaxonomyHarvester.php
+++ b/classes/TaxonomyHarvester.php
@@ -39,6 +39,7 @@ class TaxonomyHarvester extends Manager{
 			}
 			foreach($this->taxonomicResources as $authCode => $apiKey){
 				$newTid = $this->addSciname($taxonArr, $authCode);
+				if($newTid) break;
 			}
 		}
 		return $newTid;
@@ -228,7 +229,7 @@ class TaxonomyHarvester extends Manager{
 				}
 				else $this->logOrEcho('Targeted taxon return does not exist',2);
 			}
-			else $this->logOrEcho($sciName.' not found in CoL',2);
+			else $this->logOrEcho('Taxon not found',2);
 		}
 		else $this->logOrEcho('ERROR harvesting COL name: null input name',1);
 		return $tid;

--- a/collections/editor/editreviewer.php
+++ b/collections/editor/editreviewer.php
@@ -11,7 +11,7 @@ $collid = filter_var($_REQUEST['collid'], FILTER_SANITIZE_NUMBER_INT);
 $displayMode = array_key_exists('display', $_REQUEST) ? filter_var($_REQUEST['display'], FILTER_SANITIZE_NUMBER_INT) : '1';
 $faStatus = array_key_exists('fastatus', $_REQUEST) ? filter_var($_REQUEST['fastatus'], FILTER_SANITIZE_NUMBER_INT) : '';
 $frStatus = array_key_exists('frstatus', $_REQUEST)? filter_var($_REQUEST['frstatus'], FILTER_SANITIZE_STRING) : '1,2';
-$filterFieldName = array_key_exists('ffieldname', $_POST) ? filter_var($_POST['ffieldname'], FILTER_SANITIZE_STRING) : '';
+$filterFieldName = array_key_exists('ffieldname', $_REQUEST) ? filter_var($_REQUEST['ffieldname'], FILTER_SANITIZE_STRING) : '';
 $editor = array_key_exists('editor', $_REQUEST) ? filter_var($_REQUEST['editor'], FILTER_SANITIZE_STRING) : '';
 $queryOccid = array_key_exists('occid', $_REQUEST) ? filter_var($_REQUEST['occid'], FILTER_SANITIZE_NUMBER_INT) : '';
 $startDate = array_key_exists('startdate', $_REQUEST) ? filter_var($_REQUEST['startdate'], FILTER_SANITIZE_STRING) : '';
@@ -81,7 +81,8 @@ if(!$recCnt) $recCnt = $reviewManager->getEditCnt();
 
 $subCnt = $limitCnt*($pageNum + 1);
 if($subCnt > $recCnt) $subCnt = $recCnt;
-$navPageBase = 'editreviewer.php?collid='.$collid.'&display='.$displayMode.'&fastatus='.$faStatus.'&frstatus='.$frStatus.'&editor='.$editor.'&reccnt='.$recCnt;
+$navPageBase = 'editreviewer.php?collid='.$collid.'&display='.$displayMode.'&fastatus='.$faStatus.'&frstatus='.$frStatus.'&ffieldname='.$filterFieldName.
+	'&startdate='.$startDate.'&enddate='.$endDate.'&editor='.$editor.'&reccnt='.$recCnt;
 
 $navStr = '<div class="navbarDiv" style="float:right;">';
 if($pageNum) $navStr .= '<a href="'.$navPageBase.'&pagenum='.($pageNum-1).'&limitcnt='.$limitCnt.'" title="'.$LANG['PREVIOUS'].' '.$limitCnt.' '.$LANG['RECORDS1'].'">&lt;&lt;</a>';

--- a/collections/individual/index.php
+++ b/collections/individual/index.php
@@ -1395,7 +1395,7 @@ $traitArr = $indManager->getTraitArr();
 					<?php
 					ob_flush();
 					flush();
-					$rawArchArr = $indManager->checkArchive();
+					$rawArchArr = $indManager->checkArchive($guid);
 					if($rawArchArr && $rawArchArr['obj']){
 						$archArr = $rawArchArr['obj'];
 						if($isEditor){

--- a/collections/specprocessor/processor.php
+++ b/collections/specprocessor/processor.php
@@ -61,7 +61,7 @@ $statusStr = "";
 				$specManager->setProjVariables($spprid);
 				if($action == 'Process Images'){
 					if($specManager->getProjectType() == 'iplant'){
-						$imageProcessor = new ImageProcessor($specManager->getConn());
+						$imageProcessor = new ImageProcessor();
 						echo '<ul>';
 						$imageProcessor->setLogMode(3);
 						$imageProcessor->setCollid($collid);
@@ -95,9 +95,9 @@ $statusStr = "";
 						if($specManager->getLgMaxFileSize()) $imageProcessor->setLgFileSizeLimit($specManager->getLgMaxFileSize());
 						if($specManager->getJpgQuality()) $imageProcessor->setJpgQuality($specManager->getJpgQuality());
 						$imageProcessor->setUseImageMagick($specManager->getUseImageMagick());
-						$imageProcessor->setWebImg($_POST['webimg']);
-						$imageProcessor->setTnImg($_POST['createtnimg']);
-						$imageProcessor->setLgImg($_POST['createlgimg']);
+						$imageProcessor->setMedProcessingCode($_POST['webimg']);
+						$imageProcessor->setTnProcessingCode($_POST['createtnimg']);
+						$imageProcessor->setLgProcessingCode($_POST['createlgimg']);
 						$imageProcessor->setCreateNewRec($_POST['createnewrec']);
 						$imageProcessor->setImgExists($_POST['imgexists']);
 						$imageProcessor->setKeepOrig(0);
@@ -111,7 +111,7 @@ $statusStr = "";
 				}
 				elseif($action == 'mapImageFile'){
 					//Process csv file with remote image urls
-					$imageProcessor = new ImageProcessor($specManager->getConn());
+					$imageProcessor = new ImageProcessor();
 					echo '<ul>';
 					$imageProcessor->setLogMode(3);
 					$imageProcessor->setCollid($collid);

--- a/collections/specprocessor/standalone_scripts/ImageBatchHandler.php
+++ b/collections/specprocessor/standalone_scripts/ImageBatchHandler.php
@@ -39,12 +39,9 @@ if($webFileSizeLimit) $imageProcessor->setWebFileSizeLimit($webFileSizeLimit);
 if($lgFileSizeLimit) $imageProcessor->setLgFileSizeLimit($lgFileSizeLimit);
 $imageProcessor->setJpgQuality($jpgQuality);
 
-if(isset($webImg) && $webImg) $imageProcessor->setWebImg($webImg);
-elseif(isset($createWebImg) && $createWebImg) $imageProcessor->setCreateWebImg($createWebImg);
-if(isset($tnImg) && $tnImg) $imageProcessor->setTnImg($tnImg);
-elseif(isset($createTnImg) && $createTnImg) $imageProcessor->setCreateTnImg($createTnImg);
-if(isset($lgImg) && $lgImg) $imageProcessor->setLgImg($lgImg);
-elseif(isset($createLgImg) && $createLgImg) $imageProcessor->setCreateLgImg($createLgImg);
+if(isset($webImg) && $webImg) $imageProcessor->setMedProcessingCode($webImg);
+if(isset($tnImg) && $tnImg) $imageProcessor->setTnProcessingCode($tnImg);
+if(isset($lgImg) && $lgImg) $imageProcessor->setLgProcessingCode($lgImg);
 $imageProcessor->setKeepOrig($keepOrig);
 $imageProcessor->setCreateNewRec($createNewRec);
 if(isset($imgExists)) $imageProcessor->setImgExists($imgExists);

--- a/config/symbbase.php
+++ b/config/symbbase.php
@@ -2,7 +2,7 @@
 header('X-Frame-Options: DENY');
 header('Cache-control: private'); // IE 6 FIX
 date_default_timezone_set('America/Phoenix');
-$CODE_VERSION = '3.0.9';
+$CODE_VERSION = '3.0.10';
 
 if(!isset($CLIENT_ROOT) && isset($clientRoot)) $CLIENT_ROOT = $clientRoot;
 if(substr($CLIENT_ROOT,-1) == '/') $CLIENT_ROOT = substr($CLIENT_ROOT,0,strlen($CLIENT_ROOT)-1);


### PR DESCRIPTION
* Taxonomy Harvesting minor adjustments

- Check resources before interpretation and again after interpretation
- If name is matched within one recourse, skip the unnecessary step to check other resources
- Synchronize display text

* Refactor ImageLocalProcessor and resolve various bugs

- Provide support for input file to include medium and thumbnail image derivatives
- Expand Image Map processing to allow mapping file to include any images table field name
- Expand images insert function to handle any valid field found within images table
- Merge duplicate actions into shared private functions
- MD5 hash large version of image input file, but don't overwrite hash if supplied by source, unless image is not modified by upload scripts
- Handle BOM characters at start of csv file.
- Trim header elements for testing column names.
- Enforce default action of accepting derivative urls supplied within a csv image map file
- Improve uriExists function
- Make sure to remove staging images

* Occurrence Public Display page

- Allow occurrence archive (deleted occurrences) to be searchable by GUID (occurrenceID, recordID), thus reporting when a record is deleted

* Checklist multi-polygon map Issue

- Multipolygons defined within a checklist fail to map within both simple and dynamic maps

* Suppress geo ref index during stats update

* Occurrence Reviewer bug

- Fix for field name and start and end date filter variables failing to be carried forward when advancing to pages beyond 1000 records https://github.com/BioKIC/Symbiota/issues/335

* Collection metadata editor bug

- Reset contact array to ensure that JSON string is standardized as a non-associated array Resolves issue: https://github.com/BioKIC/Symbiota/issues/487

