### PR TITLE
Hotfix 2024 06 24 (#1527)

### DIFF
--- a/classes/GlossaryManager.php
+++ b/classes/GlossaryManager.php
@@ -62,11 +62,15 @@ class GlossaryManager extends Manager {
 			$sqlWhere .= ') ';
 		}
 		if($language) $sqlWhere .= 'AND (g.language = "'.$this->cleanInStr($language).'") ';
-		if($tid) $sqlWhere .= 'AND (t.tid = '.$tid.' OR t2.tid = '.$tid.') ';
+		if($tid) $sqlWhere .= 'AND (taxalink.tid = '.$tid.' OR taxalink2.tid = '.$tid.') ';
 		$sql = 'SELECT DISTINCT g.glossid, g.term, g.definition, tl.relationshipType, g2.glossid as glossid2, g2.term AS term2, g2.definition AS def2
 			FROM glossary g LEFT JOIN glossarytermlink tl ON g.glossid = tl.glossgrpid
 			LEFT JOIN glossary g2 ON tl.glossid = g2.glossid ';
-		if($tid) $sql .= 'INNER JOIN glossarytermlink tl ON g.glossid = tl.glossid INNER JOIN glossarytaxalink t ON tl.glossgrpid = t.glossid INNER JOIN glossarytaxalink t2 ON g.glossid = t2.glossid ';
+		if($tid){
+			$sql .= 'LEFT JOIN glossarytermlink termlink ON g.glossid = termlink.glossid
+				LEFT JOIN glossarytaxalink taxalink ON termlink.glossgrpid = taxalink.glossid
+				LEFT JOIN glossarytaxalink taxalink2 ON g.glossid = taxalink2.glossid ';
+		}
 		if($sqlWhere) $sql .= 'WHERE '.substr($sqlWhere, 3);
 		if($rs = $this->conn->query($sql)){
 			while($r = $rs->fetch_object()){

--- a/classes/ImageShared.php
+++ b/classes/ImageShared.php
@@ -1081,6 +1081,7 @@ class ImageShared{
 						$block_size = hexdec($block_size[1]);
 						while(!feof($handle)) {
 							$i += $block_size;
+							if(!$block_size) return false;
 							$new_block .= fread($handle, $block_size);
 							if(isset($new_block[$i]) && $new_block[$i]=="\xFF") {
 								// New block detected, check for SOF marker

--- a/config/symbbase.php
+++ b/config/symbbase.php
@@ -2,7 +2,7 @@
 header('X-Frame-Options: DENY');
 header('Cache-control: private'); // IE 6 FIX
 date_default_timezone_set('America/Phoenix');
-$CODE_VERSION = '3.0.31';
+$CODE_VERSION = '3.0.32';
 
 if(!isset($CLIENT_ROOT) && isset($clientRoot)) $CLIENT_ROOT = $clientRoot;
 if(substr($CLIENT_ROOT,-1) == '/') $CLIENT_ROOT = substr($CLIENT_ROOT,0,strlen($CLIENT_ROOT)-1);


### PR DESCRIPTION
* Hotfix 2024-06-24
- Image tools -- Return false when file size cannot be determined within getImgDim1 function
- Glossary (resolves issue: https://github.com/BioKIC/Symbiota/issues/1526) -- SQL error causing term list display to fail when a taxon group was included in the search -- Change table linkages associated with taxon group condition to LEFT JOINs so that all terms are displayed, including those without linkages to **synonyms**

